### PR TITLE
chore: add stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - bug
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. 
+  Thank you for your contributions!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 14
 exemptLabels:
   - bug
   - security
+  - never-stale
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,6 +13,8 @@ staleLabel: wontfix
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. 
-  Thank you for your contributions!
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+closeComment: >
+  This issue was closed due to inactivity. Please feel free to still 
+  comment or give :+1: :-1:. We might reopen it due to broad interest.
+  Thank you for your contributions!


### PR DESCRIPTION
## What ?
I would like to introduce [stale bot](https://github.com/apps/stale) to this repositorry (and later the others of the visjs family). This means issues that are open for 60 days or longer get a stale warning and than get closed after 14 days.

Bugs and security problems will not be closed automatically.

## Why?
In my experience the number of issues are always growing. The main problem here are the feature-requests that never get implemented and questions that nobody whats or can answer. This issues pile up and glutter the maintenance process. A project becomes almost unmaintainable if there are more than 30 open issues.

What do you folks think?
