### PR TITLE
vis#4142: add style options of fill & stroke per point 

### DIFF
--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -12,7 +12,6 @@
   <link href="../css/bootstrap.css" rel="stylesheet">
   <!-- Tipue vendor css -->
   <link href="../css/tipuesearch.css" rel="stylesheet">
-  
   <link href="../css/style.css" rel="stylesheet">
 
 
@@ -227,10 +226,12 @@
     </tr>
     <tr>
       <td>style</td>
-      <td>number</td>
+      <td>number or object</td>
       <td>no</td>
       <td>The data value, required for graph styles <code>dot-color</code> and
-        <code>dot-size</code>.
+        <code>dot-size</code>.  If an object is supplied, this allows styling on
+        a per-point basis.  The object should be in the form of
+        <code>{ "fill":"red", "stroke":"#999" }</code>.
       </td>
     </tr>
     <tr>
@@ -369,7 +370,7 @@ var options = {
       <td class="indent">dataColor.fill</td>
       <td>string</td>
       <td>'#7DC1FF'</td>
-      <td>The fill color of the dots or bars. Applicable when using styles <code>dot-size</code>, <code>bar-size</code>, or <code>line</code>.</td>  
+      <td>The fill color of the dots or bars. Applicable when using styles <code>dot-size</code>, <code>bar-size</code>, or <code>line</code>.</td>
     </tr>
     <tr parent="dataColor" class="hidden">
       <td class="indent">dataColor.stroke</td>
@@ -446,8 +447,7 @@ var options = {
         <li><code>z    </code> - z-coordinate in graph units</li>
         <li><code>style</code> - if present, the data value for this point</li>
         </ul>
-        
-        </td>
+      </td>
     </tr>
 
     <tr>
@@ -498,8 +498,8 @@ var options = {
       <td>showLegend</td>
       <td>boolean</td>
       <td>none</td>
-      <td>If true, a legend is drawn for the graph (if the graph type supports it). 
-          By default a legend is drawn for dot and dot-color style graphs. 
+      <td>If true, a legend is drawn for the graph (if the graph type supports it).
+          By default a legend is drawn for dot and dot-color style graphs.
       </td>
     </tr>
     <tr>
@@ -549,7 +549,7 @@ var options = {
       </td>
     </tr>
     <!-- Can't define separate entries for content, line and dot objects here,
-         because toggleTable() can't handle multiple levels of collapsibles --> 
+         because toggleTable() can't handle multiple levels of collapsibles -->
     <tr parent="tooltipStyle" class="hidden">
       <td class="indent">tooltipStyle.content.padding</td>
       <td>string</td>

--- a/examples/graph3d/15_styling_per_point.html
+++ b/examples/graph3d/15_styling_per_point.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html>
+<head>
+  <title>Graph 3D styles</title>
+
+  <style>
+    body {font: 10pt arial;}
+  </style>
+
+  <script type="text/javascript" src="../../dist/vis-graph3d.min.js"></script>
+
+  <script type="text/javascript">
+    var data = null;
+    var graph = null;
+
+    function custom(x, y) {
+      return (-Math.sin(x/Math.PI) * Math.cos(y/Math.PI) * 10 + 10);
+    }
+
+    // Called when the Visualization API is loaded.
+    function drawVisualization() {
+      var style = document.getElementById('style').value;
+      var showPerspective = document.getElementById('perspective').checked;
+      var xBarWidth = parseFloat(document.getElementById('xBarWidth').value) || undefined;
+      var yBarWidth = parseFloat(document.getElementById('yBarWidth').value) || undefined;
+      var withValue = ['bar-color', 'bar-size', 'dot-size', 'dot-color'].indexOf(style) != -1;
+
+      // Create and populate a data table.
+      data = [];
+      colors = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'];
+
+      // create some nice looking data with sin/cos
+      var steps = 7;  // number of datapoints will be steps*steps
+      var axisMax = 12;
+      var axisStep = axisMax / steps;
+      for (var x = 0; x <= axisMax; x+=axisStep) {
+        for (var y = 0; y <= axisMax; y+=axisStep) {
+          var z = custom(x,y);
+          if (withValue) {
+            data.push({x:x, y:y, z:z, style: {
+              fill: colors[x/axisStep],
+              stroke: '#999'
+            }});
+          }
+          else {
+            data.push({x:x, y:y, z: z});
+          }
+        }
+      }
+
+      // specify options
+      var options = {
+        width:  '600px',
+        height: '600px',
+        style: style,
+        xBarWidth: xBarWidth,
+        yBarWidth: yBarWidth,
+        showPerspective: showPerspective,
+        showGrid: true,
+        showShadow: false,
+        keepAspectRatio: true,
+        verticalRatio: 0.5
+      };
+
+      var camera = graph ? graph.getCameraPosition() : null;
+
+      // create our graph
+      var container = document.getElementById('mygraph');
+      graph = new vis.Graph3d(container, data, options);
+
+      if (camera) graph.setCameraPosition(camera); // restore camera position
+
+      document.getElementById('style').onchange = drawVisualization;
+      document.getElementById('perspective').onchange = drawVisualization;
+      document.getElementById('xBarWidth').onchange = drawVisualization;
+      document.getElementById('yBarWidth').onchange = drawVisualization;
+    }
+  </script>
+
+</head>
+
+<body onload="drawVisualization()">
+
+<p>
+  <label for="style"> Style:
+    <select id="style">
+      <option value="bar">bar</option>
+      <option value="bar-color" selected>bar-color</option>
+      <option value="bar-size">bar-size</option>
+
+      <option value="dot">dot</option>
+      <option value="dot-line">dot-line</option>
+      <option value="dot-color">dot-color</option>
+      <option value="dot-size">dot-size</option>
+
+      <option value="grid">grid</option>
+      <option value="line">line</option>
+      <option value="surface">surface</option>
+    </select>
+  </label>
+</p>
+
+<p>
+  <label for="perspective">
+    <input type="checkbox" id="perspective" checked> Show perspective
+  </label>
+</p>
+
+<p>
+  <label for="xBarWidth"> Bar width X:
+    <input type="text" id="xBarWidth" value="" style="width:50px;"> (only applicable for styles "bar" and "bar-color")
+  </label>
+</p>
+<p>
+  <label for="yBarWidth"> Bar width Y:
+    <input type="text" id="yBarWidth" value="" style="width:50px;"> (only applicable for styles "bar" and "bar-color")
+  </label>
+</p>
+
+<div id="mygraph"></div>
+
+<div id="info"></div>
+</body>
+</html>

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1521,7 +1521,17 @@ Graph3d.prototype._getColorsRegular = function(point) {
  */
 Graph3d.prototype._getColorsColor = function(point) {
   // calculate the color based on the value
-  var color, borderColor;
+  var color, borderColor, pointStyle;
+   if (point && point.point && point.point.data && point.point.data.style) {
+    pointStyle = point.point.data.style;
+  }
+  if (pointStyle && typeof pointStyle === 'object' &&
+      pointStyle.fill && pointStyle.stroke ) {
+    return {
+      fill: pointStyle.fill,
+      border: pointStyle.stroke
+    }
+  }
 
   if (typeof point.point.value === "string") {
     color = point.point.value;


### PR DESCRIPTION
This PR was originally introduced by @boorad with https://github.com/almende/vis/pull/4142

- :heavy_check_mark: docs
- :heavy_check_mark: example

----

Graph3d data points can now support the following style object in addition to numbers:

```js
{
  "x":1,
  "y":0,
  "z":3686,
  "style": {
    "fill":"red",
    "stroke":"#000"
  }
}
```