### PR TITLE
vis#4262: add tooltip delay option

### DIFF
--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -539,6 +539,15 @@ var options = {
       </td>
     </tr>
 
+    <tr>
+      <td>tooltipDelay</td>
+      <td>number</td>
+      <td>300</td>
+      <td>The delay time for the tooltip to appear when the mouse cursor
+        hovers over an x-y grid tile.
+      </td>
+    </tr>
+
     <tr class='toggle collapsible' onclick="toggleTable('optionTable','tooltipStyle', this);">
       <td><span parent="tooltipStyle" class="right-caret"></span> tooltipStyle</td>
       <td>Object</td>

--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -543,7 +543,7 @@ var options = {
       <td>tooltipDelay</td>
       <td>number</td>
       <td>300</td>
-      <td>The delay time for the tooltip to appear when the mouse cursor
+      <td>The delay time (in ms) for the tooltip to appear when the mouse cursor
         hovers over an x-y grid tile.
       </td>
     </tr>

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -69,6 +69,7 @@ Graph3d.DEFAULTS = {
 
   style            : Graph3d.STYLE.DOT,
   tooltip          : false,
+  tooltipDelay     : 300,
 
   tooltipStyle     : {
       content : {
@@ -2005,7 +2006,7 @@ Graph3d.prototype._onClick = function (event) {
  * @param {Event}  event   A mouse move event
  */
 Graph3d.prototype._onTooltip = function (event) {
-  var delay = 300; // ms
+  var delay = this.tooltipDelay; // ms
   var boundingRect = this.frame.getBoundingClientRect();
   var mouseX = getMouseX(event) - boundingRect.left;
   var mouseY = getMouseY(event) - boundingRect.top;

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -69,7 +69,7 @@ Graph3d.DEFAULTS = {
 
   style            : Graph3d.STYLE.DOT,
   tooltip          : false,
-  tooltipDelay     : 300,
+  tooltipDelay     : 300, // milliseconds
 
   tooltipStyle     : {
       content : {

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -74,6 +74,7 @@ var OPTIONKEYS = [
   'xCenter',
   'yCenter',
   'zoomable',
+  'tooltipDelay',
   'ctrlToZoom'
 ];
 

--- a/lib/graph3d/options.js
+++ b/lib/graph3d/options.js
@@ -92,6 +92,7 @@ let allOptions = {
     ]
   },
   tooltip      : { boolean: bool, 'function': 'function' },
+  tooltipDelay : { number: number },
   tooltipStyle : {
     content: {
       color       : { string },


### PR DESCRIPTION
This PR was originally introduced by @eanar with https://github.com/almende/vis/pull/4262

- :heavy_check_mark: docs

----

Small change to allow setting the tooltip delay from the options settings:

```
var options = {
        ...
        tooltipDelay: 300,
        ...
}
```