### PR TITLE
Fix xaxis font

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1132,6 +1132,7 @@ Graph3d.prototype.drawAxisLabelXRotate = function (ctx, point3d, text, armAngle,
     ctx.get
     ctx.translate( point2d.x, point2d.y);
     ctx.rotate( Math.PI / 2 );
+    ctx.fillStyle = this.axisColor;
     ctx.fillText(text, point2d.x/100, point2d.y/100 );
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
@@ -1169,6 +1170,7 @@ Graph3d.prototype.drawAxisLabelYRotate = function (ctx, point3d, text, armAngle,
     ctx.get
     ctx.translate( point2d.x, point2d.y);
     ctx.rotate( (Math.PI / 2) * -1 );
+    ctx.fillStyle = this.axisColor;
     ctx.fillText(text, point2d.x/100, point2d.y/100 );
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
@@ -1179,6 +1181,7 @@ Graph3d.prototype.drawAxisLabelYRotate = function (ctx, point3d, text, armAngle,
     ctx.get
     ctx.translate( point2d.x, point2d.y);
     ctx.rotate( Math.PI / 2 );
+    ctx.fillStyle = this.axisColor;
     ctx.fillText(text, point2d.x/100, point2d.y/100 );
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1129,7 +1129,6 @@ Graph3d.prototype.drawAxisLabelXRotate = function (ctx, point3d, text, armAngle,
   var point2d = this._convert3Dto2D(point3d);
   if (Math.cos(armAngle * 2) > 0) {
     ctx.save();
-    ctx.get
     ctx.translate( point2d.x, point2d.y);
     ctx.rotate( Math.PI / 2 );
     ctx.fillStyle = this.axisColor;
@@ -1167,7 +1166,6 @@ Graph3d.prototype.drawAxisLabelYRotate = function (ctx, point3d, text, armAngle,
   var point2d = this._convert3Dto2D(point3d);
   if (Math.cos(armAngle * 2) < 0 && Math.sin(armAngle * 2) < 0) {
     ctx.save();
-    ctx.get
     ctx.translate( point2d.x, point2d.y);
     ctx.rotate( (Math.PI / 2) * -1 );
     ctx.fillStyle = this.axisColor;
@@ -1178,7 +1176,6 @@ Graph3d.prototype.drawAxisLabelYRotate = function (ctx, point3d, text, armAngle,
     ctx.restore();
   } else if (Math.cos(armAngle * 2) < 0 ) {
     ctx.save();
-    ctx.get
     ctx.translate( point2d.x, point2d.y);
     ctx.rotate( Math.PI / 2 );
     ctx.fillStyle = this.axisColor;


### PR DESCRIPTION
Hi,

This fixes an issue where the drawing of the X axis labels ignores the given `axisColor` style at certain angles.

This becomes very obvious e.g. when modifying the basic example with:

``` 
   var options = {
        axisFontSize: 24,
        axisColor: '#aDaDaD',
        showPerspective: false,
        cameraPosition: {horizontal: 0, vertical: 1.7, distance: 2},
    };
```

For Y/Z the issue did not manifest (even though the code has the same issue) because by then the style is set on the context from before.

I also noticed some additional inconsistencies in the code (that are not fixed by this PR):

`drawAxisLabelXRotate` sets `ctx.textAlign`, `ctx.textBaseline` and modifies `point2d.y` *after* drawing the text and right before restoring the context (first if case). So these lines will have no effect.

It should probably be changed to set these properties explicitly before drawing the text. From `console.log` I know that it is currently implicitly using `ctx.textAlign == 'left'` and `ctx.textBaseline == 'alphabetic'` in my tests, but it may be different depending on the environment. Similar issue in `drawAxisLabelYRotate`.

