### PR TITLE
Fix several issues with surface plots: surfaceColors, shadow

### DIFF
--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -563,6 +563,13 @@ var options = {
       <td>Show shadow on the graph.</td>
     </tr>
     <tr>
+      <td>showSurfaceGrid</td>
+      <td>boolean</td>
+      <td>true</td>
+      <td>If true, grid lines are drawn on the surface of the graph itself
+        (only effective if <code>style: 'surface'</code>.</td>
+    </tr>
+    <tr>
       <td>style</td>
       <td>string</td>
       <td>'dot'</td>

--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -508,6 +508,12 @@ var options = {
         Only applicable when the provided data contains an animation.</td>
     </tr>
     <tr>
+      <td>showGrayBottom</td>
+      <td>boolean</td>
+      <td>false</td>
+      <td>If true, draw the bottom side of the surface in gray.</td>
+    </tr>
+    <tr>
       <td>showGrid</td>
       <td>boolean</td>
       <td>true</td>

--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -390,7 +390,7 @@ var options = {
 
     <tr class='toggle collapsible' onclick="toggleTable('optionTable','surfaceColors', this);">
         <td><span parent="surfaceColors" class="right-caret"></span> surfaceColors</td>
-        <td>array or object</td>
+        <td>boolean, array or object</td>
         <td><code>['#FF0000', '#FFF000', '#00FF00', '#68E8FB', '#000FFF']</code></td>
         <td>When <code>surfaceColors</code> is set, the surface will be colored according to the colors provided. If it is an object it must have the <code>hue</code> key, it will then be converted into an array according to the following hue values provided:</td>
       </tr>

--- a/examples/graph3d/16_styling_surface.html
+++ b/examples/graph3d/16_styling_surface.html
@@ -64,7 +64,8 @@
           showPerspective: true,
           showGrayBottom: true,
           showGrid: true,
-          showShadow: false,
+          showShadow: true,
+          showSurfaceGrid: false,
           keepAspectRatio: true,
           verticalRatio: 0.5
         };

--- a/examples/graph3d/16_styling_surface.html
+++ b/examples/graph3d/16_styling_surface.html
@@ -62,6 +62,7 @@
           height: "600px",
           style: "surface",
           showPerspective: true,
+          showGrayBottom: true,
           showGrid: true,
           showShadow: false,
           keepAspectRatio: true,

--- a/examples/graph3d/playground/index.html
+++ b/examples/graph3d/playground/index.html
@@ -141,6 +141,10 @@
                 <td>showShadow</td>
                 <td><input type="checkbox" id="showShadow" /></td>
             </tr>
+            <tr>
+                <td>showSurfaceGrid</td>
+                <td><input type="checkbox" id="showSurfaceGrid" checked /></td>
+            </tr>
 
             <tr>
                 <td>keepAspectRatio</td>

--- a/examples/graph3d/playground/index.html
+++ b/examples/graph3d/playground/index.html
@@ -109,6 +109,10 @@
                 <td><input type="checkbox" id="showAnimationControls" checked /></td>
             </tr>
             <tr>
+                <td>showGrayBottom</td>
+                <td><input type="checkbox" id="showGrayBottom" /></td>
+            </tr>
+            <tr>
                 <td>showGrid</td>
                 <td><input type="checkbox" id="showGrid" checked /></td>
             </tr>

--- a/examples/graph3d/playground/playground.js
+++ b/examples/graph3d/playground/playground.js
@@ -413,6 +413,7 @@ function getOptions() {
     showPerspective:   (document.getElementById("showPerspective").checked != false),
     showLegend:        (document.getElementById("showLegend").checked != false),
     showShadow:        (document.getElementById("showShadow").checked != false),
+    showSurfaceGrid:   (document.getElementById("showSurfaceGrid").checked != false),
     keepAspectRatio:   (document.getElementById("keepAspectRatio").checked != false),
     verticalRatio:      Number(document.getElementById("verticalRatio").value) || undefined,
     animationInterval:  Number(document.getElementById("animationInterval").value) || undefined,

--- a/examples/graph3d/playground/playground.js
+++ b/examples/graph3d/playground/playground.js
@@ -405,6 +405,7 @@ function getOptions() {
     height:             document.getElementById("height").value,
     style:              document.getElementById("style").value,
     showAnimationControls: (document.getElementById("showAnimationControls").checked != false),
+    showGrayBottom:    (document.getElementById("showGrayBottom").checked != false),
     showGrid:          (document.getElementById("showGrid").checked != false),
     showXAxis:         (document.getElementById("showXAxis").checked != false),
     showYAxis:         (document.getElementById("showYAxis").checked != false),

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1854,6 +1854,7 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
   var topSideVisible = true;
   var fillStyle;
   var strokeStyle;
+  var cosViewAngle;
 
   if (this.showGrayBottom || this.showShadow) {
     // calculate the cross product of the two vectors from center
@@ -1862,9 +1863,22 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
     // for calculating light intensity
     var aDiff = Point3d.subtract(cross.trans, point.trans);
     var bDiff = Point3d.subtract(top.trans, right.trans);
-    var crossproduct = Point3d.crossProduct(aDiff, bDiff);
+    var surfaceNormal = Point3d.crossProduct(aDiff, bDiff);
 
-    topSideVisible = (crossproduct.z > 0);
+    if (this.showPerspective) {
+      let surfacePosition = Point3d.avg(
+        Point3d.avg(point.trans, cross.trans),
+        Point3d.avg(right.trans, top.trans));
+      // This corresponds to diffuse lighting with light source at (0, 0, 0).
+      // More generally, we would need `surfacePosition - lightPosition`:
+      cosViewAngle = -Point3d.dotProduct(
+        surfaceNormal.normalize(),
+        surfacePosition.normalize())
+    }
+    else {
+      cosViewAngle = surfaceNormal.z / surfaceNormal.length();
+    }
+    topSideVisible = cosViewAngle > 0;
   }
 
   if (topSideVisible) {
@@ -1901,7 +1915,7 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
       var s    = 1; // saturation
       var v    = 1; // value
       if (this.showShadow) {
-        v = (1 + crossproduct.z / crossproduct.length()) / 2;  // value. TODO: scale
+        v = (1 + cosViewAngle) / 2;  // value. TODO: scale
         fillStyle = this._hsv2rgb(h, s, v);
         strokeStyle = fillStyle;
       }

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -51,6 +51,7 @@ Graph3d.DEFAULTS = {
   showGrid         : true,
   showPerspective  : true,
   showShadow       : false,
+  showSurfaceGrid  : true,
   keepAspectRatio  : true,
   rotateAxisLabels : true,
   verticalRatio    : 0.5,    // 0.1 to 1.0, where 1.0 results in a 'cube'
@@ -1925,18 +1926,22 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
       if (this.showShadow) {
         v = (1 + cosViewAngle) / 2;  // value. TODO: scale
         fillStyle = this._hsv2rgb(h, s, v);
-        strokeStyle = fillStyle;
       }
       else  {
         v = 1;
         fillStyle = this._hsv2rgb(h, s, v);
-        strokeStyle = this.axisColor; // TODO: should be customizable
       }
     }
   }
   else {
     fillStyle = 'gray';
-    strokeStyle = this.axisColor;
+  }
+
+  if (this.showSurfaceGrid) {
+    strokeStyle = this.axisColor; // TODO: should be customizable
+  }
+  else {
+    strokeStyle = fillStyle;
   }
 
   ctx.lineWidth = this._getStrokeWidth(point);

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1863,8 +1863,6 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
     var aDiff = Point3d.subtract(cross.trans, point.trans);
     var bDiff = Point3d.subtract(top.trans, right.trans);
     var crossproduct = Point3d.crossProduct(aDiff, bDiff);
-    var len = crossproduct.length();
-    // FIXME: there is a bug with determining the surface side (shadow or colored)
 
     topSideVisible = (crossproduct.z > 0);
   }
@@ -1903,7 +1901,7 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
       var s    = 1; // saturation
       var v    = 1; // value
       if (this.showShadow) {
-        v = Math.min(1 + (crossproduct.x / len) / 2, 1);  // value. TODO: scale
+        v = (1 + crossproduct.z / crossproduct.length()) / 2;  // value. TODO: scale
         fillStyle = this._hsv2rgb(h, s, v);
         strokeStyle = fillStyle;
       }

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1909,6 +1909,13 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
       var maxB = colors[endIndex].b;
       var b = minB + ratioWithin*(maxB - minB);
 
+      if (this.showShadow) {
+        var v = (1 + cosViewAngle) / 2;  // value. TODO: scale
+        r *= v;
+        g *= v;
+        b *= v;
+      }
+
       fillStyle = `RGB(${r}, ${g}, ${b})`;
     } else {
       var h    = ratio * 240;

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -47,6 +47,7 @@ Graph3d.DEFAULTS = {
   showXAxis        : true,
   showYAxis        : true,
   showZAxis        : true,
+  showGrayBottom   : false,
   showGrid         : true,
   showPerspective  : true,
   showShadow       : false,
@@ -1881,7 +1882,7 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
     topSideVisible = cosViewAngle > 0;
   }
 
-  if (topSideVisible) {
+  if (topSideVisible || !this.showGrayBottom) {
 
     // calculate Hue from the current value. At vMin the hue is 240, at vMax the hue is 0
     var vAvg = (point.point.value + right.point.value + top.point.value + cross.point.value) / 4;

--- a/lib/graph3d/Point3d.js
+++ b/lib/graph3d/Point3d.js
@@ -53,6 +53,27 @@ Point3d.avg = function(a, b) {
 };
 
 /**
+ * Scale the provided point by a scalar, returns p*c
+ * @param {Point3d} p
+ * @param {number} c
+ * @return {Point3d} p*c
+ */
+Point3d.scalarProduct = function(p, c) {
+  return new Point3d(p.x * c, p.y * c, p.z * c);
+};
+
+/**
+ * Calculate the dot product of the two provided points, returns a.b
+ * Documentation: http://en.wikipedia.org/wiki/Dot_product
+ * @param {Point3d} a
+ * @param {Point3d} b
+ * @return {Point3d} dot product a.b
+ */
+Point3d.dotProduct = function(a, b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+};
+
+/**
  * Calculate the cross product of the two provided points, returns axb
  * Documentation: http://en.wikipedia.org/wiki/Cross_product
  * @param {Point3d} a
@@ -71,7 +92,7 @@ Point3d.crossProduct = function(a, b) {
 
 
 /**
- * Rtrieve the length of the vector (or the distance from this point to the origin
+ * Retrieve the length of the vector (or the distance from this point to the origin
  * @return {number}  length
  */
 Point3d.prototype.length = function() {
@@ -81,5 +102,15 @@ Point3d.prototype.length = function() {
           this.z * this.z
   );
 };
+
+
+/**
+ * Return a normalized vector pointing in the same direction.
+ * @return {Point3d}  normalized
+ */
+Point3d.prototype.normalize = function() {
+  return Point3d.scalarProduct(this, 1/this.length());
+};
+
 
 module.exports = Point3d;

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -61,6 +61,7 @@ var OPTIONKEYS = [
   'showGrid',
   'showPerspective',
   'showShadow',
+  'showSurfaceGrid',
   'keepAspectRatio',
   'rotateAxisLabels',
   'verticalRatio',

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -57,6 +57,7 @@ var OPTIONKEYS = [
   'showXAxis',
   'showYAxis',
   'showZAxis',
+  'showGrayBottom',
   'showGrid',
   'showPerspective',
   'showShadow',
@@ -247,7 +248,6 @@ function setDefaults(src, dst) {
 
   // Following are internal fields, not part of the user settings
   dst.margin = 10;                  // px
-  dst.showGrayBottom = false;       // TODO: this does not work correctly
   dst.showTooltip = false;
   dst.onclick_callback = null;
   dst.eye = new Point3d(0, 0, -1);  // TODO: set eye.z about 3/4 of the width of the window?

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -477,8 +477,12 @@ function setDataColor(dataColor, dst) {
  * @param {Object} dst 
  */
 function setSurfaceColor(surfaceColors, dst) {
-  if(surfaceColors === undefined) {
+  if(surfaceColors === undefined || surfaceColors === true) {
     return;    // Nothing to do
+  }
+  if (surfaceColors === false) {
+    dst.surfaceColors = undefined;
+    return;
   }
 
   if (dst.surfaceColors === undefined) {

--- a/lib/graph3d/options.js
+++ b/lib/graph3d/options.js
@@ -84,6 +84,7 @@ let allOptions = {
   showLegend        : { boolean: bool, 'undefined': 'undefined' },
   showPerspective   : { boolean: bool },
   showShadow        : { boolean: bool },
+  showSurfaceGrid   : { boolean: bool },
   showXAxis         : { boolean: bool },
   showYAxis         : { boolean: bool },
   showZAxis         : { boolean: bool },

--- a/lib/graph3d/options.js
+++ b/lib/graph3d/options.js
@@ -31,7 +31,7 @@ let surfaceColorsOptions = {
     colorStops  : { number },
     __type__    : { object },
   },
-  __type__    : { array, object },
+  __type__    : { boolean: bool, array, object },
 };
 
 /**

--- a/lib/graph3d/options.js
+++ b/lib/graph3d/options.js
@@ -79,6 +79,7 @@ let allOptions = {
   yMax              : { number, 'undefined': 'undefined' },
   zMax              : { number, 'undefined': 'undefined' },
   showAnimationControls: { boolean: bool, 'undefined': 'undefined' },
+  showGrayBottom    : { boolean: bool },
   showGrid          : { boolean: bool },
   showLegend        : { boolean: bool, 'undefined': 'undefined' },
   showPerspective   : { boolean: bool },


### PR DESCRIPTION
Hi,

in preparation for another feature (letting the user specify colormaps), I noticed several problems in `_redrawSurfaceGraphPoint` that I wanted to fix beforehand:

- there was no working public API to disable `surfaceColors` mode and use the `_hsv2rgb` based code that was already present in this method
- fix lighting calculation for showShadow option. This option was not really accessible by the user anyway, but after making it accessible by fixing the first point, it looked visually pretty weird to me.
- fix a bug with how the topSideVisible which led to some surfaces being grayed out even if they were still viewed from the top at small angles (before this PR, this would occur if both showShadow and showPerspective were true)
- add an option `showGrayBottom` (which was already mentioned in the code) to choose whether this should be done
- apply `showShadow` when `surfaceColors` are used (previously, shadows were not used in this case)
- add option `showSurfaceGrid` to turn on/off the lines on the surface (this was previously handled very inconsistently depending on whether surfaceColors, showShadows, and other options were on or not)

Let me know, if I should change anything else or rename some of the new options.

Best, Thomas

