### PR TITLE
Resolve drawing methods via `this`

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -728,20 +728,15 @@ Graph3d.prototype.setPointDrawingMethod = function() {
  * Determine which functions to use to draw axis labels.
  */
 Graph3d.prototype.setAxisLabelMethod = function () {
-  var method_x, method_y, method_z;
-  method_x = method_y = method_z = undefined;
-  if (this.rotateAxisLabels == true) {
-    method_x = this.drawAxisLabelXRotate;
-    method_y = this.drawAxisLabelYRotate;
-    method_z = this.drawAxisLabelZRotate;
+  if (this.rotateAxisLabels) {
+    this._drawAxisLabelX = this.drawAxisLabelXRotate;
+    this._drawAxisLabelY = this.drawAxisLabelYRotate;
+    this._drawAxisLabelZ = this.drawAxisLabelZRotate;
   } else {
-    method_x = this.drawAxisLabelX;
-    method_y = this.drawAxisLabelY;
-    method_z = this.drawAxisLabelZ;
+    this._drawAxisLabelX = this.drawAxisLabelX;
+    this._drawAxisLabelY = this.drawAxisLabelY;
+    this._drawAxisLabelZ = this.drawAxisLabelZ;
   }
-  this._drawAxisLabelX = method_x;
-  this._drawAxisLabelY = method_y;
-  this._drawAxisLabelZ = method_z;
 };
 
 /**

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -687,34 +687,34 @@ Graph3d.prototype.setPointDrawingMethod = function() {
 
   switch (this.style) {
     case Graph3d.STYLE.BAR:
-      method = Graph3d.prototype._redrawBarGraphPoint;
+      method = this._redrawBarGraphPoint;
       break;
     case Graph3d.STYLE.BARCOLOR:
-      method = Graph3d.prototype._redrawBarColorGraphPoint;
+      method = this._redrawBarColorGraphPoint;
       break;
     case Graph3d.STYLE.BARSIZE:
-      method = Graph3d.prototype._redrawBarSizeGraphPoint;
+      method = this._redrawBarSizeGraphPoint;
       break;
     case Graph3d.STYLE.DOT:
-      method = Graph3d.prototype._redrawDotGraphPoint;
+      method = this._redrawDotGraphPoint;
       break;
     case Graph3d.STYLE.DOTLINE:
-      method = Graph3d.prototype._redrawDotLineGraphPoint;
+      method = this._redrawDotLineGraphPoint;
       break;
     case Graph3d.STYLE.DOTCOLOR:
-      method = Graph3d.prototype._redrawDotColorGraphPoint;
+      method = this._redrawDotColorGraphPoint;
       break;
     case Graph3d.STYLE.DOTSIZE:
-      method = Graph3d.prototype._redrawDotSizeGraphPoint;
+      method = this._redrawDotSizeGraphPoint;
       break;
     case Graph3d.STYLE.SURFACE:
-      method = Graph3d.prototype._redrawSurfaceGraphPoint;
+      method = this._redrawSurfaceGraphPoint;
       break;
     case Graph3d.STYLE.GRID:
-      method = Graph3d.prototype._redrawGridGraphPoint;
+      method = this._redrawGridGraphPoint;
       break;
     case Graph3d.STYLE.LINE:
-      method = Graph3d.prototype._redrawLineGraphPoint;
+      method = this._redrawLineGraphPoint;
       break;
     default:
       throw new Error('Can not determine point drawing method '
@@ -731,13 +731,13 @@ Graph3d.prototype.setAxisLabelMethod = function () {
   var method_x, method_y, method_z;
   method_x = method_y = method_z = undefined;
   if (this.rotateAxisLabels == true) {
-    method_x = Graph3d.prototype.drawAxisLabelXRotate;
-    method_y = Graph3d.prototype.drawAxisLabelYRotate;
-    method_z = Graph3d.prototype.drawAxisLabelZRotate;
+    method_x = this.drawAxisLabelXRotate;
+    method_y = this.drawAxisLabelYRotate;
+    method_z = this.drawAxisLabelZRotate;
   } else {
-    method_x = Graph3d.prototype.drawAxisLabelX;
-    method_y = Graph3d.prototype.drawAxisLabelY;
-    method_z = Graph3d.prototype.drawAxisLabelZ;
+    method_x = this.drawAxisLabelX;
+    method_y = this.drawAxisLabelY;
+    method_z = this.drawAxisLabelZ;
   }
   this._drawAxisLabelX = method_x;
   this._drawAxisLabelY = method_y;


### PR DESCRIPTION
Make it easier for users to override individual methods by e.g. subclassing `Graph3d`, so one only needs to override the drawing method itself, without also having to override `setPointDrawingMethod` or `setAxisLabelMethod`.