### PR TITLE
Add colormap option to replace surfaceColors

### DIFF
--- a/docs/graph3d/index.html
+++ b/docs/graph3d/index.html
@@ -388,42 +388,49 @@ var options = {
       <td>The line width of dots, bars and lines. Applicable for all styles.</td>
     </tr>
 
-    <tr class='toggle collapsible' onclick="toggleTable('optionTable','surfaceColors', this);">
-        <td><span parent="surfaceColors" class="right-caret"></span> surfaceColors</td>
-        <td>boolean, array or object</td>
-        <td><code>['#FF0000', '#FFF000', '#00FF00', '#68E8FB', '#000FFF']</code></td>
-        <td>When <code>surfaceColors</code> is set, the surface will be colored according to the colors provided. If it is an object it must have the <code>hue</code> key, it will then be converted into an array according to the following hue values provided:</td>
+    <tr class='toggle collapsible' onclick="toggleTable('optionTable','colormap', this);">
+        <td><span parent="colormap" class="right-caret"></span> colormap</td>
+        <td>array, function</td>
+        <td>none</td>
+        <td>When <code>colormap</code> is set, the surface will be colored according to the colors provided. If it is a function it will be called with normalized values between 0 and 1 and must return the RGB values as object with keys <code>{r, g, b}</code>. If it is an object it must have the <code>hue</code> key, it will then be converted into an array according to the following hue values provided:</td>
       </tr>
-      <tr parent="surfaceColors" class="hidden">
+      <tr parent="colormap" class="hidden">
         <td class="indent">surfaceColors.hue.start</td>
         <td>number</td>
         <td>None</td>
         <td>The hue value of the maximum z value of the surface. Hue is in degrees with a period of 360.</td>
       </tr>
-      <tr parent="surfaceColors" class="hidden">
+      <tr parent="colormap" class="hidden">
         <td class="indent">surfaceColors.hue.end</td>
         <td>number</td>
         <td>None</td>
         <td>The hue value of the minimum z value of the surface. Hue is in degrees with a period of 360.</td>
       </tr>
-      <tr parent="surfaceColors" class="hidden">
+      <tr parent="colormap" class="hidden">
         <td class="indent">surfaceColors.hue.saturation</td>
         <td>number</td>
         <td>None</td>
         <td>Saturation value of all hue colors. Saturation is in percent (0 to 100).</td>
       </tr>
-      <tr parent="surfaceColors" class="hidden">
+      <tr parent="colormap" class="hidden">
         <td class="indent">surfaceColors.hue.brightness</td>
         <td>number</td>
         <td>None</td>
         <td>Brightness value of all hue colors. Brightness is in percent (0 to 100).</td>
       </tr>
-      <tr parent="surfaceColors" class="hidden">
+      <tr parent="colormap" class="hidden">
         <td class="indent">surfaceColors.hue.colorStops</td>
         <td>number</td>
         <td>None</td>
         <td>How many color stops does the hue go through between hue start and hue end.</td>
       </tr>
+
+    <tr>
+      <td>surfaceColors</td>
+      <td>boolean, array or object</td>
+      <td>none</td>
+      <td>This option is deprecated and may be removed in a future version. Please use the <code>colormap</code> option instead. Note that the <code>colormap</code> option uses the reverse array ordering (running from vMin to vMax).</td>
+    </tr>
 
     <tr>
       <td>dotSizeRatio</td>

--- a/examples/graph3d/16_styling_surface.html
+++ b/examples/graph3d/16_styling_surface.html
@@ -70,18 +70,26 @@
           verticalRatio: 0.5
         };
 
-        if (style === "hue") {
-          options.surfaceColors = {
+        if (style === "default") {
+          options.colormap = [
+            '#000FFF',
+            '#68E8FB',
+            '#00FF00',
+            '#FFF000',
+            '#FF0000',
+          ]
+        } else if (style === "hue") {
+          options.colormap = {
             hue: {
-              start: -360,
-              end: 360,
+              start: 360,
+              end: -360,
               saturation: 50,
               brightness: 100,
               colorStops: 8 // How many colour gradients do we want
             }
           };
         } else if (style === "html") {
-          options.surfaceColors = ["#FFFFFF", "#6A0DAD", "#000000"];
+          options.colormap = ["#000000", "#6A0DAD", "#FFFFFF"];
         } // else use defaults.
 
         // Instantiate our graph object.
@@ -105,12 +113,12 @@
         />
         <label for="defaultStyle">Default Configuration: </label>
         <code>
-          <pre>surfaceColors: [
-  '#FF0000',
-  '#FFF000',
-  '#00FF00',
-  '#68E8FB',
+          <pre>colormap: [
   '#000FFF',
+  '#68E8FB',
+  '#00FF00',
+  '#FFF000',
+  '#FF0000',
 ]</pre>
         </code>
       </div>
@@ -125,10 +133,10 @@
         />
         <label for="hueStyle">Hue Configuration:</label>
         <code>
-          <pre>surfaceColors: {
+          <pre>colormap: {
   hue: {
-    start: -360,
-    end: 360,
+    start: 360,
+    end: -360,
     saturation: 50,
     brightness: 100,
     colorStops: 8,
@@ -147,10 +155,10 @@
         />
         <label for="htmlStyle">HTML Hex Configuration:</label>
         <code>
-          <pre>surfaceColors: [
-  '#FFFFFF',
-  '#6A0DAD',
+          <pre>colormap: [
   '#000000',
+  '#6A0DAD',
+  '#FFFFFF',
 ]</pre>
         </code>
       </div>

--- a/examples/graph3d/16_styling_surface.html
+++ b/examples/graph3d/16_styling_surface.html
@@ -77,7 +77,11 @@
             '#00FF00',
             '#FFF000',
             '#FF0000',
-          ]
+          ];
+        } else if (style === "function") {
+          options.colormap = function(x) {
+            return {r: 255*x, g: 0, b: 0};
+          };
         } else if (style === "hue") {
           options.colormap = {
             hue: {
@@ -120,6 +124,22 @@
   '#FFF000',
   '#FF0000',
 ]</pre>
+        </code>
+      </div>
+
+      <div>
+        <input
+          type="radio"
+          name="style"
+          id="functionStyle"
+          value="function"
+          onchange="drawVisualization();"
+        />
+        <label for="functionStyle">Function Configuration:</label>
+        <code>
+          <pre>colormap: function(x) {
+  return {r: 255*x, g: 0, b: 0};
+}</pre>
         </code>
       </div>
 

--- a/examples/graph3d/16_styling_surface.html
+++ b/examples/graph3d/16_styling_surface.html
@@ -80,7 +80,7 @@
           ];
         } else if (style === "function") {
           options.colormap = function(x) {
-            return {r: 255*x, g: 0, b: 0};
+            return {r: 255*x, g: 0, b: 0, a: (1+x)/2};
           };
         } else if (style === "hue") {
           options.colormap = {
@@ -138,7 +138,7 @@
         <label for="functionStyle">Function Configuration:</label>
         <code>
           <pre>colormap: function(x) {
-  return {r: 255*x, g: 0, b: 0};
+  return {r: 255*x, g: 0, b: 0, a: (1+x)/2};
 }</pre>
         </code>
       </div>

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1896,45 +1896,24 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
     var vAvg = (point.point.value + right.point.value + top.point.value + cross.point.value) / 4;
     var ratio = (vAvg - this.valueRange.min) * this.scale.value;
 
+    // lighting factor. TODO: let user specify lighting model as function(?)
+    var v = this.showShadow ? (1 + cosViewAngle) / 2 : 1;
+
     var colors = this.surfaceColors;
     if (colors && colors.length !== 0) {
       ratio = 1 - ratio;
       var colorStops = colors.length - 1;
       var startIndex = Math.max(Math.floor(ratio * colorStops), 0);
-      var endIndex = Math.min(Math.ceil(ratio * colorStops), colorStops);
-
+      var endIndex = Math.min(startIndex + 1, colorStops);
       var ratioWithin = ratio * colorStops - startIndex;
-
-      var minR = colors[startIndex].r;
-      var maxR = colors[endIndex].r;
+      var {r: minR, g: minG, b: minB} = colors[startIndex];
+      var {r: maxR, g: maxG, b: maxB} = colors[endIndex];
       var r = minR + ratioWithin*(maxR - minR);
-
-      var minG = colors[startIndex].g;
-      var maxG = colors[endIndex].g;
       var g = minG + ratioWithin*(maxG - minG);
-
-      var minB = colors[startIndex].b;
-      var maxB = colors[endIndex].b;
       var b = minB + ratioWithin*(maxB - minB);
-
-      if (this.showShadow) {
-        var v = (1 + cosViewAngle) / 2;  // value. TODO: scale
-        r *= v;
-        g *= v;
-        b *= v;
-      }
-
-      fillStyle = `RGB(${r}, ${g}, ${b})`;
+      fillStyle = `RGB(${parseInt(r*v)}, ${parseInt(g*v)}, ${parseInt(b*v)})`;
     } else {
-      var v    = 1; // value
-      if (this.showShadow) {
-        v = (1 + cosViewAngle) / 2;  // value. TODO: scale
-        fillStyle = this._colormap(ratio, v);
-      }
-      else  {
-        v = 1;
-        fillStyle = this._colormap(ratio, v);
-      }
+      fillStyle = this._colormap(ratio, v);
     }
   }
   else {

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -862,9 +862,9 @@ Graph3d.prototype._redrawLegend = function() {
     var y;
 
     for (y = ymin; y < ymax; y++) {
-      var f = (y - ymin) / (ymax - ymin);
-      var hue = f * 240;
-      var color = this._hsv2rgb(hue, 1, 1);
+      // Need (1 - x) because y runs from top to bottom:
+      var f = 1 - (y - ymin) / (ymax - ymin);
+      var color = this._colormap(f, 1);
 
       ctx.strokeStyle = color;
       ctx.beginPath();
@@ -1611,10 +1611,9 @@ Graph3d.prototype._drawCircle = function(ctx, point, color, borderColor, size) {
  * @private
  */
 Graph3d.prototype._getColorsRegular = function(point) {
-  // calculate Hue from the current value. At vMin the hue is 240, at vMax the hue is 0
-  var hue         = (1 - (point.point.value - this.valueRange.min) * this.scale.value) * 240;
-  var color       = this._hsv2rgb(hue, 1, 1);
-  var borderColor = this._hsv2rgb(hue, 1, 0.8);
+  var f           = (point.point.value - this.valueRange.min) * this.scale.value;
+  var color       = this._colormap(f, 1);
+  var borderColor = this._colormap(f, 0.8);
 
   return {
     fill  : color,
@@ -1654,9 +1653,9 @@ Graph3d.prototype._getColorsColor = function(point) {
     borderColor = point.point.value;
   }
   else {
-    var hue     = (1 - (point.point.value - this.valueRange.min) * this.scale.value) * 240;
-    color       = this._hsv2rgb(hue, 1, 1);
-    borderColor = this._hsv2rgb(hue, 1, 0.8);
+    var f       = (point.point.value - this.valueRange.min) * this.scale.value;
+    color       = this._colormap(f, 1);
+    borderColor = this._colormap(f, 0.8);
   }
   return {
     fill   : color,
@@ -1677,6 +1676,20 @@ Graph3d.prototype._getColorsSize = function() {
     fill   : this.dataColor.fill,
     border : this.dataColor.stroke
   };
+};
+
+
+/**
+ * Determine the color corresponding to a given value on the color scale.
+ *
+ * @param {number} [x] the data value to be mapped running from 0 to 1
+ * @param {number} [v] scale factor between 0 and 1 for the color brightness
+ * @returns {string}
+ * @private
+ */
+Graph3d.prototype._colormap = function(x, v) {
+  var hue = (1 - x) * 240;
+  return this._hsv2rgb(hue, 1, v);
 };
 
 
@@ -1880,12 +1893,12 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
 
   if (topSideVisible || !this.showGrayBottom) {
 
-    // calculate Hue from the current value. At vMin the hue is 240, at vMax the hue is 0
     var vAvg = (point.point.value + right.point.value + top.point.value + cross.point.value) / 4;
-    var ratio = (1 - (vAvg - this.valueRange.min) * this.scale.value);
+    var ratio = (vAvg - this.valueRange.min) * this.scale.value;
 
     var colors = this.surfaceColors;
     if (colors && colors.length !== 0) {
+      ratio = 1 - ratio;
       var colorStops = colors.length - 1;
       var startIndex = Math.max(Math.floor(ratio * colorStops), 0);
       var endIndex = Math.min(Math.ceil(ratio * colorStops), colorStops);
@@ -1913,16 +1926,14 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
 
       fillStyle = `RGB(${r}, ${g}, ${b})`;
     } else {
-      var h    = ratio * 240;
-      var s    = 1; // saturation
       var v    = 1; // value
       if (this.showShadow) {
         v = (1 + cosViewAngle) / 2;  // value. TODO: scale
-        fillStyle = this._hsv2rgb(h, s, v);
+        fillStyle = this._colormap(ratio, v);
       }
       else  {
         v = 1;
-        fillStyle = this._hsv2rgb(h, s, v);
+        fillStyle = this._colormap(ratio, v);
       }
     }
   }
@@ -1958,12 +1969,11 @@ Graph3d.prototype._drawGridLine = function(ctx, from, to) {
      return;
   }
 
-  // calculate Hue from the current value. At vMin the hue is 240, at vMax the hue is 0
   var vAvg = (from.point.value + to.point.value) / 2;
-  var h    = (1 - (vAvg - this.valueRange.min) * this.scale.value) * 240;
+  var f    = (vAvg - this.valueRange.min) * this.scale.value;
 
   ctx.lineWidth   = this._getStrokeWidth(from) * 2;
-  ctx.strokeStyle = this._hsv2rgb(h, 1, 1);
+  ctx.strokeStyle = this._colormap(f, 1);
   this._line(ctx, from.screen, to.screen);
 };
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -106,13 +106,8 @@ Graph3d.DEFAULTS = {
     strokeWidth: 1 // px
   },
 
-  surfaceColors    : [
-    '#FF0000',
-    '#FFF000',
-    '#00FF00',
-    '#68E8FB',
-    '#000FFF',
-  ],
+  surfaceColors: autoByDefault,
+  colormap : autoByDefault,
 
   cameraPosition   : {
      horizontal: 1.0,
@@ -1416,7 +1411,7 @@ Graph3d.prototype._redrawAxis = function() {
  * @param {number} H   Hue, a value be between 0 and 360
  * @param {number} S   Saturation, a value between 0 and 1
  * @param {number} V   Value, a value between 0 and 1
- * @returns {string}
+ * @returns {Object}   {r, g, b}
  * @private
  */
 Graph3d.prototype._hsv2rgb = function(H, S, V) {
@@ -1437,7 +1432,7 @@ Graph3d.prototype._hsv2rgb = function(H, S, V) {
     default: R = 0; G = 0; B = 0; break;
   }
 
-  return 'RGB(' + parseInt(R*255) + ',' + parseInt(G*255) + ',' + parseInt(B*255) + ')';
+  return {r: R*255, g: G*255, b: B*255};
 };
 
 /**
@@ -1688,8 +1683,28 @@ Graph3d.prototype._getColorsSize = function() {
  * @private
  */
 Graph3d.prototype._colormap = function(x, v) {
-  var hue = (1 - x) * 240;
-  return this._hsv2rgb(hue, 1, v);
+  if (v === undefined) {
+    v = 1;
+  }
+
+  var colormap = this.colormap;
+  if (Array.isArray(colormap)) {
+    var maxIndex = colormap.length - 1;
+    var startIndex = Math.max(Math.floor(x * maxIndex), 0);
+    var endIndex = Math.min(startIndex + 1, maxIndex);
+    var innerRatio = x * maxIndex - startIndex;
+    var min = colormap[startIndex];
+    var max = colormap[endIndex];
+    var r = min.r + innerRatio*(max.r - min.r);
+    var g = min.g + innerRatio*(max.g - min.g);
+    var b = min.b + innerRatio*(max.b - min.b);
+  } else if (typeof colormap === 'function') {
+    var {r, g, b} = colormap(x);
+  } else {
+    var hue = (1 - x) * 240;
+    var {r, g, b} = this._hsv2rgb(hue, 1, 1);
+  }
+  return `RGB(${parseInt(r*v)}, ${parseInt(g*v)}, ${parseInt(b*v)})`;
 };
 
 
@@ -1892,29 +1907,11 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
   }
 
   if (topSideVisible || !this.showGrayBottom) {
-
     var vAvg = (point.point.value + right.point.value + top.point.value + cross.point.value) / 4;
     var ratio = (vAvg - this.valueRange.min) * this.scale.value;
-
     // lighting factor. TODO: let user specify lighting model as function(?)
     var v = this.showShadow ? (1 + cosViewAngle) / 2 : 1;
-
-    var colors = this.surfaceColors;
-    if (colors && colors.length !== 0) {
-      ratio = 1 - ratio;
-      var colorStops = colors.length - 1;
-      var startIndex = Math.max(Math.floor(ratio * colorStops), 0);
-      var endIndex = Math.min(startIndex + 1, colorStops);
-      var ratioWithin = ratio * colorStops - startIndex;
-      var {r: minR, g: minG, b: minB} = colors[startIndex];
-      var {r: maxR, g: maxG, b: maxB} = colors[endIndex];
-      var r = minR + ratioWithin*(maxR - minR);
-      var g = minG + ratioWithin*(maxG - minG);
-      var b = minB + ratioWithin*(maxB - minB);
-      fillStyle = `RGB(${parseInt(r*v)}, ${parseInt(g*v)}, ${parseInt(b*v)})`;
-    } else {
-      fillStyle = this._colormap(ratio, v);
-    }
+    fillStyle = this._colormap(ratio, v);
   }
   else {
     fillStyle = 'gray';

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1406,34 +1406,6 @@ Graph3d.prototype._redrawAxis = function() {
   }
 };
 
-/**
- * Calculate the color based on the given value.
- * @param {number} H   Hue, a value be between 0 and 360
- * @param {number} S   Saturation, a value between 0 and 1
- * @param {number} V   Value, a value between 0 and 1
- * @returns {Object}   {r, g, b}
- * @private
- */
-Graph3d.prototype._hsv2rgb = function(H, S, V) {
-  var R, G, B, C, Hi, X;
-
-  C = V * S;
-  Hi = Math.floor(H/60);  // hi = 0,1,2,3,4,5
-  X = C * (1 - Math.abs(((H/60) % 2) - 1));
-
-  switch (Hi) {
-    case 0: R = C; G = X; B = 0; break;
-    case 1: R = X; G = C; B = 0; break;
-    case 2: R = 0; G = C; B = X; break;
-    case 3: R = 0; G = X; B = C; break;
-    case 4: R = X; G = 0; B = C; break;
-    case 5: R = C; G = 0; B = X; break;
-
-    default: R = 0; G = 0; B = 0; break;
-  }
-
-  return {r: R*255, g: G*255, b: B*255};
-};
 
 /**
  *
@@ -1702,7 +1674,7 @@ Graph3d.prototype._colormap = function(x, v) {
     var {r, g, b} = colormap(x);
   } else {
     var hue = (1 - x) * 240;
-    var {r, g, b} = this._hsv2rgb(hue, 1, 1);
+    var {r, g, b} = util.HSVToRGB(hue/360, 1, 1);
   }
   return `RGB(${parseInt(r*v)}, ${parseInt(g*v)}, ${parseInt(b*v)})`;
 };

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1656,7 +1656,7 @@ Graph3d.prototype._getColorsSize = function() {
  */
 Graph3d.prototype._colormap = function(x, v=1) {
 
-  let r, g, b;
+  let r, g, b, a;
   const colormap = this.colormap;
   if (Array.isArray(colormap)) {
     const maxIndex = colormap.length - 1;
@@ -1669,12 +1669,16 @@ Graph3d.prototype._colormap = function(x, v=1) {
     g = min.g + innerRatio*(max.g - min.g);
     b = min.b + innerRatio*(max.b - min.b);
   } else if (typeof colormap === 'function') {
-    ({r, g, b} = colormap(x));
+    ({r, g, b, a} = colormap(x));
   } else {
     const hue = (1 - x) * 240;
     ({r, g, b} = util.HSVToRGB(hue/360, 1, 1));
   }
-  return `RGB(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)})`;
+  if (isNaN(a)) {
+    return `RGB(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)})`;
+  } else {
+    return `RGBA(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)}, ${a})`;
+  }
 };
 
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1673,10 +1673,10 @@ Graph3d.prototype._colormap = function(x, v=1) {
     const hue = (1 - x) * 240;
     ({r, g, b} = util.HSVToRGB(hue/360, 1, 1));
   }
-  if (isNaN(a)) {
-    return `RGB(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)})`;
-  } else {
+  if (typeof a === 'number' && !Number.isNaN(a)) {
     return `RGBA(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)}, ${a})`;
+  } else {
+    return `RGB(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)})`;
   }
 };
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1887,8 +1887,8 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
     var colors = this.surfaceColors;
     if (colors && colors.length !== 0) {
       var colorStops = colors.length - 1;
-      var startIndex = Math.floor(ratio * colorStops);
-      var endIndex = Math.ceil(ratio * colorStops);
+      var startIndex = Math.max(Math.floor(ratio * colorStops), 0);
+      var endIndex = Math.min(Math.ceil(ratio * colorStops), colorStops);
 
       var ratioWithin = ratio * colorStops - startIndex;
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -858,8 +858,8 @@ Graph3d.prototype._redrawLegend = function() {
 
     for (y = ymin; y < ymax; y++) {
       // Need (1 - x) because y runs from top to bottom:
-      var f = 1 - (y - ymin) / (ymax - ymin);
-      var color = this._colormap(f, 1);
+      const f = 1 - (y - ymin) / (ymax - ymin);
+      const color = this._colormap(f, 1);
 
       ctx.strokeStyle = color;
       ctx.beginPath();
@@ -1578,10 +1578,9 @@ Graph3d.prototype._drawCircle = function(ctx, point, color, borderColor, size) {
  * @private
  */
 Graph3d.prototype._getColorsRegular = function(point) {
-  var f           = (point.point.value - this.valueRange.min) * this.scale.value;
-  var color       = this._colormap(f, 1);
-  var borderColor = this._colormap(f, 0.8);
-
+  const f           = (point.point.value - this.valueRange.min) * this.scale.value;
+  const color       = this._colormap(f, 1);
+  const borderColor = this._colormap(f, 0.8);
   return {
     fill  : color,
     border: borderColor
@@ -1620,7 +1619,7 @@ Graph3d.prototype._getColorsColor = function(point) {
     borderColor = point.point.value;
   }
   else {
-    var f       = (point.point.value - this.valueRange.min) * this.scale.value;
+    const f     = (point.point.value - this.valueRange.min) * this.scale.value;
     color       = this._colormap(f, 1);
     borderColor = this._colormap(f, 0.8);
   }
@@ -1881,10 +1880,10 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
   }
 
   if (topSideVisible || !this.showGrayBottom) {
-    var vAvg = (point.point.value + right.point.value + top.point.value + cross.point.value) / 4;
-    var ratio = (vAvg - this.valueRange.min) * this.scale.value;
+    const vAvg = (point.point.value + right.point.value + top.point.value + cross.point.value) / 4;
+    const ratio = (vAvg - this.valueRange.min) * this.scale.value;
     // lighting factor. TODO: let user specify lighting model as function(?)
-    var v = this.showShadow ? (1 + cosViewAngle) / 2 : 1;
+    const v = this.showShadow ? (1 + cosViewAngle) / 2 : 1;
     fillStyle = this._colormap(ratio, v);
   }
   else {
@@ -1919,8 +1918,8 @@ Graph3d.prototype._drawGridLine = function(ctx, from, to) {
      return;
   }
 
-  var vAvg = (from.point.value + to.point.value) / 2;
-  var f    = (vAvg - this.valueRange.min) * this.scale.value;
+  const vAvg = (from.point.value + to.point.value) / 2;
+  const f    = (vAvg - this.valueRange.min) * this.scale.value;
 
   ctx.lineWidth   = this._getStrokeWidth(from) * 2;
   ctx.strokeStyle = this._colormap(f, 1);

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1654,29 +1654,27 @@ Graph3d.prototype._getColorsSize = function() {
  * @returns {string}
  * @private
  */
-Graph3d.prototype._colormap = function(x, v) {
-  if (v === undefined) {
-    v = 1;
-  }
+Graph3d.prototype._colormap = function(x, v=1) {
 
-  var colormap = this.colormap;
+  let r, g, b;
+  const colormap = this.colormap;
   if (Array.isArray(colormap)) {
-    var maxIndex = colormap.length - 1;
-    var startIndex = Math.max(Math.floor(x * maxIndex), 0);
-    var endIndex = Math.min(startIndex + 1, maxIndex);
-    var innerRatio = x * maxIndex - startIndex;
-    var min = colormap[startIndex];
-    var max = colormap[endIndex];
-    var r = min.r + innerRatio*(max.r - min.r);
-    var g = min.g + innerRatio*(max.g - min.g);
-    var b = min.b + innerRatio*(max.b - min.b);
+    const maxIndex = colormap.length - 1;
+    const startIndex = Math.max(Math.floor(x * maxIndex), 0);
+    const endIndex = Math.min(startIndex + 1, maxIndex);
+    const innerRatio = x * maxIndex - startIndex;
+    const min = colormap[startIndex];
+    const max = colormap[endIndex];
+    r = min.r + innerRatio*(max.r - min.r);
+    g = min.g + innerRatio*(max.g - min.g);
+    b = min.b + innerRatio*(max.b - min.b);
   } else if (typeof colormap === 'function') {
-    var {r, g, b} = colormap(x);
+    ({r, g, b} = colormap(x));
   } else {
-    var hue = (1 - x) * 240;
-    var {r, g, b} = util.HSVToRGB(hue/360, 1, 1);
+    const hue = (1 - x) * 240;
+    ({r, g, b} = util.HSVToRGB(hue/360, 1, 1));
   }
-  return `RGB(${parseInt(r*v)}, ${parseInt(g*v)}, ${parseInt(b*v)})`;
+  return `RGB(${Math.round(r*v)}, ${Math.round(g*v)}, ${Math.round(b*v)})`;
 };
 
 

--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -1890,9 +1890,7 @@ Graph3d.prototype._redrawSurfaceGraphPoint = function(ctx, point) {
       var startIndex = Math.floor(ratio * colorStops);
       var endIndex = Math.ceil(ratio * colorStops);
 
-      var startRatio = startIndex / colorStops;
-      var endRatio = endIndex / colorStops;
-      var ratioWithin = (ratio - startRatio) / (endRatio - startRatio);
+      var ratioWithin = ratio * colorStops - startIndex;
 
       var minR = colors[startIndex].r;
       var maxR = colors[endIndex].r;

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -519,15 +519,15 @@ function setSurfaceColor(surfaceColors, dst) {
       throw new Error('Surface colors colorStops is out of bounds. Expected 2 or above.');
     }
 
-    const startHue = Math.min(surfaceColors.hue.start, surfaceColors.hue.end);
-    const endHue = Math.max(surfaceColors.hue.start, surfaceColors.hue.end);
+    const startHue = surfaceColors.hue.start
+    const endHue = surfaceColors.hue.end
     const saturation = surfaceColors.hue.saturation;
     const brightness = surfaceColors.hue.brightness;
     const stops = surfaceColors.hue.colorStops;
-    const hueStepSize = (endHue - startHue) / stops;
+    const hueStepSize = (endHue - startHue) / (stops - 1);
 
-    let currentHue = startHue;
-    while (currentHue < endHue) {
+    for (let i = 0; i < stops; ++i) {
+      let currentHue = startHue + hueStepSize * i;
       let calculatedHue = currentHue % 360;
       if(calculatedHue < 0) {
         calculatedHue = 360 + calculatedHue;
@@ -539,11 +539,6 @@ function setSurfaceColor(surfaceColors, dst) {
           brightness/100
         )
       );
-      currentHue += hueStepSize;
-    }
-
-    if (surfaceColors.hue.start > surfaceColors.hue.end) {
-      rgbColors.reverse();
     }
   } else {
     throw new Error('Unsupported type of surfaceColors');

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -69,7 +69,6 @@ var OPTIONKEYS = [
   'dotSizeMinFraction',
   'dotSizeMaxFraction',
   'showAnimationControls',
-  'surfaceColors',
   'animationInterval',
   'animationPreload',
   'animationAutoStart',
@@ -293,8 +292,27 @@ function setSpecialSettings(src, dst) {
   }
 
   setDataColor(src.dataColor, dst);
-  setSurfaceColor(src.surfaceColors, dst);
   setStyle(src.style, dst);
+  if (src.surfaceColors !== undefined) {
+    console.warn(
+      '`options.surfaceColors` is deprecated and may be removed in a future ' +
+      'version. Please use `options.colormap` instead. Note that the `colormap` ' +
+      'option uses the inverse array ordering (running from vMin to vMax).')
+    if (src.colormap !== undefined) {
+      throw new Error('The `colormap` and `surfaceColors` options are mutually exclusive.');
+    }
+    if (dst.style !== 'surface') {
+      console.warn(
+        'Ignoring `surfaceColors` in graph style `' + dst.style + '` for ' +
+        'backward compatibility (only effective in `surface` plots).');
+    }
+    else {
+      setSurfaceColor(src.surfaceColors, dst);
+    }
+  }
+  else {
+    setColormap(src.colormap, dst);
+  }
   setShowLegend(src.showLegend, dst);
   setCameraPosition(src.cameraPosition, dst);
 
@@ -474,8 +492,6 @@ function setDataColor(dataColor, dst) {
 }
 
 /**
- * Converts an object that accepts a HUE keyword. This is converted to a certain amount of hex color stops. At which point:
- * the HTML hex color codes is converted into an RGB color object.
  * 
  * @param {Object | Array<string>} surfaceColors Either an object that describes the HUE, or an array of HTML hex color codes
  * @param {Object} dst 
@@ -493,52 +509,97 @@ function setSurfaceColor(surfaceColors, dst) {
     dst.surfaceColors = {};
   }
 
-  let rgbColors = [];
-
-  if(Array.isArray(surfaceColors)) {
-    if(surfaceColors.length < 2) {
-      throw new Error('Surface colors array length must be 2 or above.');
-    }
-    rgbColors = surfaceColors.map(function(colorCode){
-      if(!util.isValidHex(colorCode)) {
-        throw new Error('Invalid hex color code supplied to surfaceColors.');
-      }
-      return util.hexToRGB(colorCode);
-    });
+  let rgbColors;
+  if (Array.isArray(surfaceColors)) {
+    rgbColors = parseColorArray(surfaceColors);
   } else if (typeof surfaceColors === 'object') {
-    const hues = surfaceColors.hue;
-
-    if (hues === undefined) {
-      throw new Error('Unsupported type of surfaceColors');
-    }
-    if (hues.saturation < 0 || hues.saturation > 100) {
-      throw new Error('Surface colors saturation is out of bounds. Expected range is 0-100.');
-    }
-    if (hues.brightness < 0 || hues.brightness > 100) {
-      throw new Error('Surface colors brightness is out of bounds. Expected range is 0-100.');
-    }
-    if (hues.colorStops < 2) {
-      throw new Error('Surface colors colorStops is out of bounds. Expected 2 or above.');
-    }
-
-    const hueStep = (hues.end - hues.start) / (hues.colorStops - 1);
-
-    for (let i = 0; i < hues.colorStops; ++i) {
-      let hue = (hues.start + hueStep * i) % 360 / 360;
-      rgbColors.push(
-        util.HSVToRGB(
-          hue < 0 ? hue + 1 : hue,
-          hues.saturation/100,
-          hues.brightness/100
-        )
-      );
-    }
+    rgbColors = parseColorObject(surfaceColors.hue);
   } else {
     throw new Error('Unsupported type of surfaceColors');
   }
-
-  dst.surfaceColors = rgbColors;
+  // for some reason surfaceColors goes from vMax to vMin:
+  rgbColors.reverse();
+  dst.colormap = rgbColors;
 }
+
+
+/**
+ *
+ * @param {Object | Array<string>} colormap Either an object that describes the HUE, or an array of HTML hex color codes
+ * @param {Object} dst
+ */
+function setColormap(colormap, dst) {
+  if (colormap === undefined) {
+    return;
+  }
+
+  let rgbColors;
+  if (Array.isArray(colormap)) {
+    rgbColors = parseColorArray(colormap);
+  } else if (typeof colormap === 'object') {
+    rgbColors = parseColorObject(colormap.hue);
+  } else if (typeof colormap === 'function') {
+    rgbColors = colormap;
+  } else {
+    throw new Error('Unsupported type of colormap');
+  }
+  dst.colormap = rgbColors;
+}
+
+
+/**
+ *
+ * @param {Array} colormap
+ */
+function parseColorArray(colormap) {
+  if(colormap.length < 2) {
+    throw new Error('Colormap array length must be 2 or above.');
+  }
+  return colormap.map(function(colorCode){
+    if(!util.isValidHex(colorCode)) {
+      throw new Error(`Invalid hex color code supplied to colormap.`);
+    }
+    return util.hexToRGB(colorCode);
+  });
+}
+
+
+/**
+ * Converts an object to a certain amount of hex color stops. At which point:
+ * the HTML hex color codes is converted into an RGB color object.
+ *
+ * @param {Object} hues
+ */
+function parseColorObject(hues) {
+  if (hues === undefined) {
+    throw new Error('Unsupported type of colormap');
+  }
+  if (hues.saturation < 0 || hues.saturation > 100) {
+    throw new Error('Saturation is out of bounds. Expected range is 0-100.');
+  }
+  if (hues.brightness < 0 || hues.brightness > 100) {
+    throw new Error('Brightness is out of bounds. Expected range is 0-100.');
+  }
+  if (hues.colorStops < 2) {
+    throw new Error('colorStops is out of bounds. Expected 2 or above.');
+  }
+
+  const hueStep = (hues.end - hues.start) / (hues.colorStops - 1);
+
+  let rgbColors = [];
+  for (let i = 0; i < hues.colorStops; ++i) {
+    let hue = (hues.start + hueStep * i) % 360 / 360;
+    rgbColors.push(
+      util.HSVToRGB(
+        hue < 0 ? hue + 1 : hue,
+        hues.saturation/100,
+        hues.brightness/100
+      )
+    );
+  }
+  return rgbColors;
+}
+
 
 /**
  *

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -506,37 +506,30 @@ function setSurfaceColor(surfaceColors, dst) {
       return util.hexToRGB(colorCode);
     });
   } else if (typeof surfaceColors === 'object') {
-    if(surfaceColors.hue === undefined) {
+    const hues = surfaceColors.hue;
+
+    if (hues === undefined) {
       throw new Error('Unsupported type of surfaceColors');
     }
-    if(surfaceColors.hue.saturation < 0 || surfaceColors.hue.saturation > 100) {
+    if (hues.saturation < 0 || hues.saturation > 100) {
       throw new Error('Surface colors saturation is out of bounds. Expected range is 0-100.');
     }
-    if(surfaceColors.hue.brightness < 0 || surfaceColors.hue.brightness > 100) {
+    if (hues.brightness < 0 || hues.brightness > 100) {
       throw new Error('Surface colors brightness is out of bounds. Expected range is 0-100.');
     }
-    if(surfaceColors.hue.colorStops < 2) {
+    if (hues.colorStops < 2) {
       throw new Error('Surface colors colorStops is out of bounds. Expected 2 or above.');
     }
 
-    const startHue = surfaceColors.hue.start
-    const endHue = surfaceColors.hue.end
-    const saturation = surfaceColors.hue.saturation;
-    const brightness = surfaceColors.hue.brightness;
-    const stops = surfaceColors.hue.colorStops;
-    const hueStepSize = (endHue - startHue) / (stops - 1);
+    const hueStep = (hues.end - hues.start) / (hues.colorStops - 1);
 
-    for (let i = 0; i < stops; ++i) {
-      let currentHue = startHue + hueStepSize * i;
-      let calculatedHue = currentHue % 360;
-      if(calculatedHue < 0) {
-        calculatedHue = 360 + calculatedHue;
-      }
+    for (let i = 0; i < hues.colorStops; ++i) {
+      let hue = (hues.start + hueStep * i) % 360 / 360;
       rgbColors.push(
         util.HSVToRGB(
-          calculatedHue/360,
-          saturation/100, 
-          brightness/100
+          hue < 0 ? hue + 1 : hue,
+          hues.saturation/100,
+          hues.brightness/100
         )
       );
     }

--- a/lib/graph3d/Settings.js
+++ b/lib/graph3d/Settings.js
@@ -574,13 +574,13 @@ function parseColorObject(hues) {
   if (hues === undefined) {
     throw new Error('Unsupported type of colormap');
   }
-  if (hues.saturation < 0 || hues.saturation > 100) {
+  if (!(hues.saturation >= 0 && hues.saturation <= 100)) {
     throw new Error('Saturation is out of bounds. Expected range is 0-100.');
   }
-  if (hues.brightness < 0 || hues.brightness > 100) {
+  if (!(hues.brightness >= 0 && hues.brightness <= 100)) {
     throw new Error('Brightness is out of bounds. Expected range is 0-100.');
   }
-  if (hues.colorStops < 2) {
+  if (!(hues.colorStops >= 2)) {
     throw new Error('colorStops is out of bounds. Expected 2 or above.');
   }
 

--- a/lib/graph3d/options.js
+++ b/lib/graph3d/options.js
@@ -31,7 +31,19 @@ let surfaceColorsOptions = {
     colorStops  : { number },
     __type__    : { object },
   },
-  __type__    : { boolean: bool, array, object },
+  __type__    : { boolean: bool, array, object, 'undefined': 'undefined' },
+};
+
+let colormapOptions = {
+  hue: {
+    start       : { number },
+    end         : { number },
+    saturation  : { number },
+    brightness  : { number },
+    colorStops  : { number },
+    __type__    : { object },
+  },
+  __type__    : { array, object, 'function': 'function', 'undefined': 'undefined' },
 };
 
 /**
@@ -60,6 +72,7 @@ let allOptions = {
   ctrlToZoom        : { boolean: bool },
   xCenter           : { string },
   yCenter           : { string },
+  colormap          : colormapOptions,
   dataColor         : colorOptions,
   dotSizeMinFraction: { number },
   dotSizeMaxFraction: { number },


### PR DESCRIPTION
Hi,

first, this fixes a few remaining issues with the `surfaceColors` implementation.

Next, I've wanted to have an option that allows specifying a function that maps a value between 0 and 1 to an RGB value. This makes it possible to e.g. plug in colormaps from [chroma.js](https://github.com/gka/chroma.js) or use any custom user logic.

I believe it is probably best not to reuse `surfaceColors` for this, but replace it with a `colormap`  because

- the name `surfaceColors` implies it works only with surface plots, but I think the colormap should be usable for all plot styles
- the `surfaceColors` option previously worked only for surface plots, i.e. if we would change it to work with other styles, this might be a (minor) break in backward compatibility
- `colormap` is the more commonly used name
- the `surfaceColors` option takes colors in the order from vMax to vMin, whereas I think that it is more intuitive to pass colors in ascending order

If you disagree, it is of course trivial to just add this capability to the existing surfaceColors option.