### PR TITLE
chore(mocha): use mocharc file

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "extension": ["js"],
+  "require": ["vis-dev-utils/babel-register"],
+  "spec": ["./test/**/*.test.js"]
+}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "styles"
   ],
   "scripts": {
-    "test": "BABEL_ENV=test mocha --exit --require vis-dev-utils/babel-register",
-    "test-cov": "BABEL_ENV=test-cov nyc --reporter=lcov mocha --exit --require vis-dev-utils/babel-register",
+    "test": "BABEL_ENV=test mocha --exit",
+    "test-cov": "BABEL_ENV=test-cov nyc --reporter=lcov mocha --exit",
     "js:graph3d": "rollup --config rollup.build.js && rollup --config rollup.config.js",
     "build": "npm run js:graph3d",
     "watch": "rollup --watch --config rollup.config.js",


### PR DESCRIPTION
This prevents Mocha from picking up unwanted configuration from parent directories and merging it with command line arguments, potentially failing the tests due to misconfiguration. Also it's much nicer to manage JSON files compared to package.json script lines.