### PR TITLE
package.json: fix "types" path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "jsnext": "esnext/esm/vis-graph3d.js",
   "main": "peer/umd/vis-graph3d.js",
   "module": "peer/esm/vis-graph3d.js",
-  "types": "declarations/index.d.ts",
+  "types": "peer/index.d.ts",
   "homepage": "https://visjs.github.io/vis-graph3d/",
   "license": "(Apache-2.0 OR MIT)",
   "repository": {


### PR DESCRIPTION
Current release do not correclty reference type declarations in `package.json`. Using the `index.d.ts` from `peer` fixes it.

btw, can you please do a new NPM release when merged, as published version is not usable from TypeScript.