### PR TITLE
perf: remove add/remove event listener polyfills

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -526,11 +526,11 @@ Graph3d.prototype.create = function () {
   };
   // TODO: these events are never cleaned up... can give a 'memory leakage'
 
-  util.addEventListener(this.frame.canvas, "mousedown", onmousedown);
-  util.addEventListener(this.frame.canvas, "touchstart", ontouchstart);
-  util.addEventListener(this.frame.canvas, "mousewheel", onmousewheel);
-  util.addEventListener(this.frame.canvas, "mousemove", ontooltip);
-  util.addEventListener(this.frame.canvas, "click", onclick);
+  this.frame.canvas.addEventListener("mousedown", onmousedown);
+  this.frame.canvas.addEventListener("touchstart", ontouchstart);
+  this.frame.canvas.addEventListener("mousewheel", onmousewheel);
+  this.frame.canvas.addEventListener("mousemove", ontooltip);
+  this.frame.canvas.addEventListener("click", onclick);
 
   // add the new graph to the container element
   this.containerElement.appendChild(this.frame);
@@ -2079,8 +2079,8 @@ Graph3d.prototype._onMouseDown = function (event) {
   this.onmouseup = function (event) {
     me._onMouseUp(event);
   };
-  util.addEventListener(document, "mousemove", me.onmousemove);
-  util.addEventListener(document, "mouseup", me.onmouseup);
+  document.addEventListener("mousemove", me.onmousemove);
+  document.addEventListener("mouseup", me.onmouseup);
   util.preventDefault(event);
 };
 
@@ -2253,8 +2253,8 @@ Graph3d.prototype._onTouchStart = function (event) {
   this.ontouchend = function (event) {
     me._onTouchEnd(event);
   };
-  util.addEventListener(document, "touchmove", me.ontouchmove);
-  util.addEventListener(document, "touchend", me.ontouchend);
+  document.addEventListener("touchmove", me.ontouchmove);
+  document.addEventListener("touchend", me.ontouchend);
 
   this._onMouseDown(event);
 };

--- a/lib/graph3d/Slider.js
+++ b/lib/graph3d/Slider.js
@@ -310,8 +310,8 @@ Slider.prototype._onMouseDown = function (event) {
   this.onmouseup = function (event) {
     me._onMouseUp(event);
   };
-  util.addEventListener(document, "mousemove", this.onmousemove);
-  util.addEventListener(document, "mouseup", this.onmouseup);
+  document.addEventListener("mousemove", this.onmousemove);
+  document.addEventListener("mouseup", this.onmouseup);
   util.preventDefault(event);
 };
 


### PR DESCRIPTION
These are polyfills for very old browsers. We don't polyfill these browsers using core-js (i.e. it most likely doesn't work in them anyway) and barely anyone is using them nowadays.