### PR TITLE
use exactly version 5.0.5 of vis-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "uuid": "9.0.1",
         "vis-data": "7.1.9",
         "vis-dev-utils": "4.0.45",
-        "vis-util": "5.0.7"
+        "vis-util": "5.0.5"
       },
       "funding": {
         "type": "opencollective",
@@ -41,7 +41,7 @@
         "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
         "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "vis-data": "^6.3.0 || ^7.0.0",
-        "vis-util": "^5.0.1"
+        "vis-util": "5.0.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -18723,9 +18723,9 @@
       }
     },
     "node_modules/vis-util": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.7.tgz",
-      "integrity": "sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.5.tgz",
+      "integrity": "sha512-NQHl/gkJYW7+MEJ0Ed4oo5nsvtUl95rfruZQj69T2oSLBrnDfxUJzBZ00rA5fNuSLW9DL+FemdMOVGvMu6kIrQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -18736,7 +18736,7 @@
       },
       "peerDependencies": {
         "@egjs/hammerjs": "^2.0.0",
-        "component-emitter": "^1.3.0 || ^2.0.0"
+        "component-emitter": "^1.3.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
     "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
     "vis-data": "^6.3.0 || ^7.0.0",
-    "vis-util": "^5.0.1"
+    "vis-util": "5.0.5"
   },
   "devDependencies": {
     "@egjs/hammerjs": "2.0.17",
@@ -85,6 +85,6 @@
     "uuid": "9.0.1",
     "vis-data": "7.1.9",
     "vis-dev-utils": "4.0.45",
-    "vis-util": "5.0.7"
+    "vis-util": "5.0.5"
   }
 }


### PR DESCRIPTION
As mentioned in [this comment on #1064](https://github.com/visjs/vis-graph3d/issues/1064#issuecomment-1957316462), the upstream package `vis-util` has removed the add/remove event listeners API in https://github.com/visjs/vis-util/pull/1417, in version 5.0.6 specifically.

This causes errors to be displayed in the console when the user lets go of the mouse button after dragging the graph, including in the official examples.
```
Uncaught TypeError: (void 0) is not a function
```

This PR changes the `package.json` to use exactly 5.0.5 of `vis-util`; the newest version before the removal of the listeners API.

With this change, `npm install` unfortunately prints this resolution error:
```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: vis-graph3d@0.0.0-no-version
npm error Found: component-emitter@2.0.0
npm error node_modules/component-emitter
npm error   dev component-emitter@"2.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer component-emitter@"^1.3.0" from vis-util@5.0.5
npm error node_modules/vis-util
npm error   dev vis-util@"5.0.5" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
```
Running `npm install --force` overrides this and allows the installation to complete.

After that, doing a build produces a `vis-graph3d.min.js` file that doesn't produce that `Uncaught TypeError` anymore.