### PR TITLE
fix(#1064): graph rotation via pointer getting stuck even after pointer button release

### DIFF
--- a/lib/graph3d/Graph3d.js
+++ b/lib/graph3d/Graph3d.js
@@ -2160,8 +2160,9 @@ Graph3d.prototype._onMouseUp = function (event) {
   this.leftButtonDown = false;
 
   // remove event listeners here
-  util.removeEventListener(document, "mousemove", this.onmousemove);
-  util.removeEventListener(document, "mouseup", this.onmouseup);
+  document.removeEventListener("mousemove", this.onmousemove);
+  document.removeEventListener("mouseup", this.onmouseup);
+
   util.preventDefault(event);
 };
 
@@ -2276,8 +2277,8 @@ Graph3d.prototype._onTouchMove = function (event) {
 Graph3d.prototype._onTouchEnd = function (event) {
   this.touchDown = false;
 
-  util.removeEventListener(document, "touchmove", this.ontouchmove);
-  util.removeEventListener(document, "touchend", this.ontouchend);
+  document.removeEventListener("touchmove", this.ontouchmove);
+  document.removeEventListener("touchend", this.ontouchend);
 
   this._onMouseUp(event);
 };

--- a/lib/graph3d/Slider.js
+++ b/lib/graph3d/Slider.js
@@ -353,8 +353,8 @@ Slider.prototype._onMouseUp = function () {
   this.frame.style.cursor = "auto";
 
   // remove event listeners
-  util.removeEventListener(document, "mousemove", this.onmousemove);
-  util.removeEventListener(document, "mouseup", this.onmouseup);
+  document.removeEventListener("mousemove", this.onmousemove);
+  document.removeEventListener("mouseup", this.onmouseup);
 
   util.preventDefault();
 };


### PR DESCRIPTION
This was caused by https://github.com/visjs/vis-util/pull/1417 that removed custom `removeEventListener` polyfill when it was still used here.

Apologies for that.

Closes #1064
Closes #1109